### PR TITLE
Fix resolveProject and resolveTeam silent fallback bug

### DIFF
--- a/src/__tests__/issue.test.ts
+++ b/src/__tests__/issue.test.ts
@@ -15,6 +15,7 @@ const mockIssues = vi.fn();
 const mockIssue = vi.fn();
 const mockSearchIssues = vi.fn();
 const mockTeams = vi.fn();
+const mockTeam = vi.fn();
 const mockUsers = vi.fn();
 
 // Mock @linear/sdk
@@ -29,6 +30,7 @@ vi.mock("@linear/sdk", () => ({
     searchIssues: mockSearchIssues,
     createIssueRelation: mockCreateIssueRelation,
     teams: mockTeams,
+    team: mockTeam,
     users: mockUsers,
   })),
 }));
@@ -63,6 +65,7 @@ describe("issue commands", () => {
     mockIssue.mockReset();
     mockSearchIssues.mockReset();
     mockTeams.mockReset();
+    mockTeam.mockReset();
     mockUsers.mockReset();
 
     // Default mock for users (needed by resolveUser)
@@ -291,6 +294,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -349,6 +353,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -397,6 +402,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -645,7 +651,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockSearchIssues.mockResolvedValue({ nodes: [] });
-      mockTeams.mockResolvedValue({ nodes: [] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-uuid" }] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -755,6 +761,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -815,6 +822,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -864,6 +872,7 @@ describe("issue commands", () => {
       mockTeams.mockResolvedValue({
         nodes: [{ id: "team-1", key: "MAIN" }],
       });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -124,7 +124,10 @@ async function resolveProject(
   const projects = await client.projects({
     filter: { name: { eqIgnoreCase: project } },
   });
-  return projects.nodes[0]?.id ?? project;
+  if (!projects.nodes[0]) {
+    throw new ValidationError(`No project matching "${project}"`);
+  }
+  return projects.nodes[0].id;
 }
 
 async function resolveTeam(
@@ -137,7 +140,10 @@ async function resolveTeam(
   const teams = await client.teams({
     filter: { name: { eqIgnoreCase: team } },
   });
-  return teams.nodes[0]?.id ?? team;
+  if (!teams.nodes[0]) {
+    throw new ValidationError(`No team matching "${team}"`);
+  }
+  return teams.nodes[0].id;
 }
 
 export function registerIssueCommands(program: Command): void {
@@ -316,13 +322,8 @@ export function registerIssueCommands(program: Command): void {
         const format = getFormat(globalOpts.format);
 
         // Resolve team
-        const teams = await client.teams({
-          filter: { name: { eqIgnoreCase: opts.team } },
-        });
-        let teamId = teams.nodes[0]?.id;
-        if (!teamId) {
-          teamId = opts.team;
-        }
+        const teamId = await resolveTeam(client, opts.team);
+        const team = await client.team(teamId);
 
         const input: Record<string, unknown> = {
           title: opts.title,
@@ -356,16 +357,13 @@ export function registerIssueCommands(program: Command): void {
 
         // State
         if (opts.state) {
-          const teamKey = teams.nodes[0]?.key;
-          if (teamKey) {
-            input.stateId = await resolveState(
-              opts.state,
-              teamKey,
-              client,
-              agentId,
-              credentialsDir
-            );
-          }
+          input.stateId = await resolveState(
+            opts.state,
+            team.key,
+            client,
+            agentId,
+            credentialsDir
+          );
         }
 
         // Labels


### PR DESCRIPTION
## Summary
- `resolveProject` and `resolveTeam` now throw `ValidationError` when a name lookup finds no matches, instead of silently returning the raw name string as an ID (which caused confusing downstream API errors)
- Refactored `issue create` to use the shared `resolveTeam` function, removing duplicated inline team resolution logic
- Updated test mocks to match new behavior (added `client.team` mock, fixed search team mock)

## Test plan
- [x] All 123 unit tests pass
- [ ] Verify `issue create --team "nonexistent"` returns a clear validation error
- [ ] Verify `issue create --project "nonexistent"` returns a clear validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)