### PR TITLE
MAIN-65: Fix OIDC publishing in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,9 +3,10 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", { "npmPublish": true }],
+    ["@semantic-release/npm", { "npmPublish": false }],
     ["@semantic-release/exec", {
-      "prepareCmd": "npm run build && npm pack && mv ebragas-linear-cli-*.tgz ebragas-linear-cli.tgz"
+      "prepareCmd": "npm run build && npm pack && mv ebragas-linear-cli-*.tgz ebragas-linear-cli.tgz",
+      "publishCmd": "npm publish --provenance --access public"
     }],
     ["@semantic-release/git", {
       "assets": ["package.json", "package-lock.json"],


### PR DESCRIPTION
## Summary

- Set `npmPublish: false` on `@semantic-release/npm` (version bumping only — its `verifyConditions` runs `npm whoami` which fails with OIDC)
- Added `publishCmd` to `@semantic-release/exec` to run `npm publish --provenance --access public` directly (OIDC works natively here)
- Removed `registry-url` from `setup-node` to prevent `NODE_AUTH_TOKEN` in `.npmrc` from interfering with OIDC

Fixes the failed Release workflow from the previous merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)