### PR TITLE
MAIN-96: Default issue create state to Todo

### DIFF
--- a/skills/linear-cli/commands.md
+++ b/skills/linear-cli/commands.md
@@ -22,6 +22,8 @@ linear issue create \
   --team Main \
   --description-file /tmp/desc.md \
   --agent <id>
+# Issues default to "Todo" state; override with --state
+linear issue create --title "Backlog item" --team Main --state "Backlog" --agent <id>
 
 # With relations (blocks/blocked-by use separate issueRelationCreate calls; partial failure exits 6)
 linear issue create --title "Subtask" --team Main --parent MAIN-42 --blocks MAIN-50 --agent <id>

--- a/src/__tests__/issue.test.ts
+++ b/src/__tests__/issue.test.ts
@@ -55,6 +55,20 @@ const validCredentials: Credentials = {
   workspaceSlug: "test-workspace",
 };
 
+function mockTeamNode() {
+  return {
+    id: "team-1",
+    key: "MAIN",
+    states: vi.fn().mockResolvedValue({
+      nodes: [
+        { name: "Todo", id: "state-todo" },
+        { name: "In Progress", id: "state-ip" },
+        { name: "Done", id: "state-done" },
+      ],
+    }),
+  };
+}
+
 describe("issue commands", () => {
   let testDir: string;
   let origStdinIsTTY: boolean | undefined;
@@ -416,9 +430,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -476,9 +488,7 @@ describe("issue commands", () => {
       const descFile = join(testDir, "desc.md");
       writeFileSync(descFile, "# From file\nDescription content");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -525,9 +535,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -593,7 +601,7 @@ describe("issue commands", () => {
         const { registerIssueCommands } = await import("../commands/issue.js");
         const { Command } = await import("commander");
 
-        mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+        mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
         mockTeam.mockResolvedValue({ key: "MAIN" });
         mockCreateIssue.mockResolvedValue({
           issue: Promise.resolve({
@@ -1012,9 +1020,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -1073,9 +1079,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -1123,9 +1127,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
-      });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
       mockCreateIssue.mockResolvedValue({
@@ -1209,7 +1211,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
       const { ValidationError } = await import("../errors.js");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
       mockProjects.mockResolvedValue({ nodes: [] });
       mockCreateIssue.mockResolvedValue({
@@ -1246,7 +1248,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockCreateTemplate.mockResolvedValue({
         success: true,
         template: { id: "template-1", name: "Daily Standup" },
@@ -1298,7 +1300,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockCreateTemplate.mockResolvedValue({
         success: true,
         template: { id: "template-2", name: "Morning Check-in" },
@@ -1347,7 +1349,7 @@ describe("issue commands", () => {
         { id: "t-2", name: "Regular Template", type: "issue", templateData: "{}", team: Promise.resolve(null) },
         { id: "t-3", name: "Daily Report", type: "recurringIssue", templateData: "{}", team: Promise.resolve({ id: "team-1" }) },
       ]);
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1453,7 +1455,7 @@ describe("issue commands", () => {
       const { ValidationError } = await import("../errors.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1481,7 +1483,7 @@ describe("issue commands", () => {
       const { ValidationError } = await import("../errors.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1508,7 +1510,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockUsers.mockResolvedValue({
         nodes: [{ id: "user-1", name: "Alice", email: "alice@example.com", displayName: "Alice" }],
       });
@@ -1563,7 +1565,7 @@ describe("issue commands", () => {
       };
       writeFileSync(join(testDir, "test-bot.cache.json"), JSON.stringify(cacheData));
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeams.mockResolvedValue({ nodes: [mockTeamNode()] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
       mockCreateTemplate.mockResolvedValue({
         success: true,

--- a/src/__tests__/issue.test.ts
+++ b/src/__tests__/issue.test.ts
@@ -417,7 +417,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -460,6 +460,7 @@ describe("issue commands", () => {
           teamId: "team-1",
           description: "Issue body",
           priority: 2,
+          stateId: "state-todo",
         })
       );
 
@@ -476,7 +477,7 @@ describe("issue commands", () => {
       writeFileSync(descFile, "# From file\nDescription content");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -525,7 +526,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -592,7 +593,7 @@ describe("issue commands", () => {
         const { registerIssueCommands } = await import("../commands/issue.js");
         const { Command } = await import("commander");
 
-        mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+        mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
         mockTeam.mockResolvedValue({ key: "MAIN" });
         mockCreateIssue.mockResolvedValue({
           issue: Promise.resolve({
@@ -1012,7 +1013,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -1073,7 +1074,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -1123,7 +1124,7 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
 
       mockTeams.mockResolvedValue({
-        nodes: [{ id: "team-1", key: "MAIN" }],
+        nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }],
       });
       mockTeam.mockResolvedValue({ key: "MAIN" });
 
@@ -1208,7 +1209,8 @@ describe("issue commands", () => {
       const { Command } = await import("commander");
       const { ValidationError } = await import("../errors.js");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
+      mockTeam.mockResolvedValue({ key: "MAIN" });
       mockProjects.mockResolvedValue({ nodes: [] });
       mockCreateIssue.mockResolvedValue({
         issue: Promise.resolve({
@@ -1244,7 +1246,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
       mockCreateTemplate.mockResolvedValue({
         success: true,
         template: { id: "template-1", name: "Daily Standup" },
@@ -1296,7 +1298,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
       mockCreateTemplate.mockResolvedValue({
         success: true,
         template: { id: "template-2", name: "Morning Check-in" },
@@ -1345,7 +1347,7 @@ describe("issue commands", () => {
         { id: "t-2", name: "Regular Template", type: "issue", templateData: "{}", team: Promise.resolve(null) },
         { id: "t-3", name: "Daily Report", type: "recurringIssue", templateData: "{}", team: Promise.resolve({ id: "team-1" }) },
       ]);
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1451,7 +1453,7 @@ describe("issue commands", () => {
       const { ValidationError } = await import("../errors.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1479,7 +1481,7 @@ describe("issue commands", () => {
       const { ValidationError } = await import("../errors.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
 
       const program = new Command();
       program.option("--agent <id>").option("--credentials-dir <path>").option("--format <format>");
@@ -1506,7 +1508,7 @@ describe("issue commands", () => {
       const { registerIssueCommands } = await import("../commands/issue.js");
       const { Command } = await import("commander");
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
       mockUsers.mockResolvedValue({
         nodes: [{ id: "user-1", name: "Alice", email: "alice@example.com", displayName: "Alice" }],
       });
@@ -1561,7 +1563,7 @@ describe("issue commands", () => {
       };
       writeFileSync(join(testDir, "test-bot.cache.json"), JSON.stringify(cacheData));
 
-      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN" }] });
+      mockTeams.mockResolvedValue({ nodes: [{ id: "team-1", key: "MAIN", states: vi.fn().mockResolvedValue({ nodes: [{ name: "Todo", id: "state-todo" }, { name: "In Progress", id: "state-ip" }, { name: "Done", id: "state-done" }] }) }] });
       mockTeam.mockResolvedValue({ key: "MAIN" });
       mockCreateTemplate.mockResolvedValue({
         success: true,

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -140,9 +140,9 @@ async function resolveProject(
 async function resolveTeam(
   client: LinearClient,
   team: string
-): Promise<string> {
+): Promise<{ id: string; key: string | null }> {
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(team)) {
-    return team;
+    return { id: team, key: null };
   }
   const teams = await client.teams({
     filter: { name: { eqIgnoreCase: team } },
@@ -150,7 +150,7 @@ async function resolveTeam(
   if (!teams.nodes[0]) {
     throw new ValidationError(`No team matching "${team}"`);
   }
-  return teams.nodes[0].id;
+  return { id: teams.nodes[0].id, key: teams.nodes[0].key };
 }
 
 export function registerIssueCommands(program: Command): void {
@@ -346,7 +346,7 @@ export function registerIssueCommands(program: Command): void {
         const format = getFormat(globalOpts.format);
 
         // Resolve team
-        const teamId = await resolveTeam(client, opts.team);
+        const { id: teamId, key: teamKey } = await resolveTeam(client, opts.team);
 
         const input: Record<string, unknown> = {
           title: opts.title,
@@ -389,10 +389,10 @@ export function registerIssueCommands(program: Command): void {
 
         // State (defaults to "Todo" when not specified)
         {
-          const team = await client.team(teamId);
+          const key = teamKey ?? (await client.team(teamId)).key;
           input.stateId = await resolveState(
             opts.state ?? "Todo",
-            team.key,
+            key,
             client,
             agentId,
             credentialsDir
@@ -687,7 +687,7 @@ export function registerIssueCommands(program: Command): void {
 
         const searchOpts: Record<string, unknown> = {};
         if (opts.team) {
-          searchOpts.teamId = await resolveTeam(client, opts.team);
+          searchOpts.teamId = (await resolveTeam(client, opts.team)).id;
         }
         if (opts.includeComments) {
           searchOpts.includeComments = true;
@@ -790,7 +790,7 @@ export function registerIssueCommands(program: Command): void {
           );
         }
 
-        const teamId = await resolveTeam(client, opts.team);
+        const { id: teamId, key: teamKey } = await resolveTeam(client, opts.team);
 
         const interval = parseInt(opts.interval, 10);
         if (isNaN(interval) || interval < 1) {
@@ -822,10 +822,10 @@ export function registerIssueCommands(program: Command): void {
         }
 
         if (opts.state) {
-          const team = await client.team(teamId);
+          const key = teamKey ?? (await client.team(teamId)).key;
           templateData.stateId = await resolveState(
             opts.state,
-            team.key,
+            key,
             client,
             agentId,
             credentialsDir
@@ -858,7 +858,7 @@ export function registerIssueCommands(program: Command): void {
       await runWithClient(globalOpts, async (client) => {
         const format = getFormat(globalOpts.format);
 
-        const teamId = opts.team ? await resolveTeam(client, opts.team) : null;
+        const teamId = opts.team ? (await resolveTeam(client, opts.team)).id : null;
         const allTemplates = await client.templates;
 
         type RecurringTemplate = {

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -330,7 +330,7 @@ export function registerIssueCommands(program: Command): void {
     .option("--description-file <path>", "Read description from file")
     .option("--assignee <user>", "Assign to user")
     .option("--delegate <agent>", "Delegate to agent")
-    .option("--state <state>", "Initial workflow state")
+    .option("--state <state>", "Initial workflow state (default: Todo)")
     .option("--label <label>", "Add label (repeatable)", collectArray, [])
     .option("--priority <priority>", "Priority level (0-4)")
     .option("--project <project>", "Add to project")
@@ -387,11 +387,11 @@ export function registerIssueCommands(program: Command): void {
           );
         }
 
-        // State
-        if (opts.state) {
+        // State (defaults to "Todo" when not specified)
+        {
           const team = await client.team(teamId);
           input.stateId = await resolveState(
-            opts.state,
+            opts.state ?? "Todo",
             team.key,
             client,
             agentId,


### PR DESCRIPTION
## Summary
- `issue create` now defaults `--state` to "Todo" when not specified, ensuring planned work lands on the board instead of Triage
- Updated `--state` option help text to indicate the default
- Updated skill command reference to document the new default behavior

Fixes MAIN-96

## Test plan
- [x] All existing tests pass (167/167)
- [x] Test verifies `stateId: "state-todo"` is set when `--state` is omitted
- [ ] Manual: `linear issue create --title "Test" --team Main --agent <id>` creates issue in Todo state
- [ ] Manual: `linear issue create --title "Test" --team Main --state "Backlog" --agent <id>` respects explicit state

🤖 Generated with [Claude Code](https://claude.com/claude-code)